### PR TITLE
build: support CI & docker compose

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,3 +34,46 @@ jobs:
         args: release
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # https://github.com/docker/metadata-action
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          117503445/uni-translate
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+          type=raw,value=latest
+
+    # https://github.com/docker/build-push-action
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          117503445/uni-translate
+          xgd16/uni-translate
         tags: |
           type=schedule
           type=ref,event=branch

--- a/config.container.yaml
+++ b/config.container.yaml
@@ -1,0 +1,43 @@
+# 基础 http 配置
+server:
+  name: uniTranslate
+  address: "0.0.0.0:9431"
+  cacheMode: redis # redis , mem , off 模式 mem 会将翻译结果存储到程序内存中 模式 off 不写入任何缓存
+  cachePlatform: false # 执行缓存key生成是否包含平台 (会影响项目启动时自动初始化存储的key)
+  cacheRefreshOnStartup: false # 启动时是否从数据库刷新缓存 (会先清除缓存里所有的 缓存 在从数据库逐条初始化 数据 慎用!!!)
+  key: "hdasdhasdhsahdkasjfsoufoqjoje" # http api 对接时的密钥
+  keyMode: 1 # 模式 1 直接传入 key 做验证 模式 2 使用 key 加密加签数据进行验证
+  configDeviceMode: "xdb" # xdb 内置数据库 mysql 使用 MySQL 作为配置存储引擎
+  configDeviceMySqlDb: "default" # 翻译配置的数据库设置
+  cacheWriteToStorage: false # 是否将缓存写入到数据库
+  requestRecordKeepDays: 7 # 请求记录保留天数
+
+
+# 数据库
+database:
+  default:
+    type: "mysql"
+    link: "root:jsnSvEEdb4as9v@tcp(mysql:3306)/uni_translate?charset=utf8mb4&parseTime=true&loc=Local"
+    createdAt: "createTime"
+    updatedAt: "updateTime"
+    debug: true
+
+# redis
+redis:
+  default:
+    address: redis:6379
+    db: 0
+    pass: "sGQsTh3DHrj8Yq"
+
+# 日志
+logger:
+  path:    "./log/default"
+  level:   "all"
+  stdout:  false
+  writerColorEnable: true
+
+# GrayLog 支持
+grayLog:
+  open: false
+  host:
+  port:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   uni-translate:
-    image: 117503445/uni-translate
+    image: xgd16/uni-translate
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  uni-translate:
+    image: 117503445/uni-translate
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./config.container.yaml:/workspace/config.yaml
+    ports:
+      - 9431:9431
+  mysql:
+    image: mysql:8.4.0
+    environment:
+      MYSQL_ROOT_PASSWORD: jsnSvEEdb4as9v
+      MYSQL_DATABASE: uni_translate
+    # ports:
+    #   - 3306:3306
+  redis:
+    image: redis:7.2.4
+    command: redis-server --requirepass sGQsTh3DHrj8Yq
+    # ports:
+    #   - 6379:6379


### PR DESCRIPTION
支持了在 CI 中构建并推送镜像至 Docker Hub，并且允许用户使用 docker compose up 一键部署。

请将 `117503445/uni-translate` 修改为你自己的镜像名，并在 GitHub Action 中设置 `DOCKERHUB_USERNAME` 和 `DOCKERHUB_TOKEN`

Supports building and pushing images in CI to Docker Hub, and allows users to deploy with docker compose up in one click.

Please change `117503445/uni-translate` to your own image name and set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the GitHub Action